### PR TITLE
Adjust PayPal integration in some environments

### DIFF
--- a/upload/modules/Resources/pages/resources/listener.php
+++ b/upload/modules/Resources/pages/resources/listener.php
@@ -2,7 +2,7 @@
 /*
  *	Made by Samerton
  *  https://github.com/NamelessMC/Nameless/
- *  NamelessMC version 2.0.0-pr5
+ *  NamelessMC version 2.0.0-pr10
  *
  *  License: MIT
  *
@@ -32,17 +32,16 @@ if(isset($_GET['key']) && $_GET['key'] == $data){
 
 	if (!function_exists('getallheaders')) {
 		function getallheaders() {
-			$headers = [];
-			foreach ($_SERVER as $name => $value) {
-				if (substr($name, 0, 5) == 'HTTP_') {
-					$headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+		    	$build = array();
+		    	foreach($_SERVER as $name => $value) {
+				if (strpos($name, 'HTTP_PAYPAL') !== false) {
+					$build[str_replace('_','-', substr($name, 5))] = $value;
 				}
-			}
-			return $headers;
+            		}
+            		return $build;
 		}
-	} else {
-		$headers = getallheaders();
 	}
+	$headers = getallheaders();
 	$headers = array_change_key_case($headers, CASE_UPPER);
 
 	$signatureVerification = new \PayPal\Api\VerifyWebhookSignature();
@@ -105,9 +104,6 @@ if(isset($_GET['key']) && $_GET['key'] == $data){
 				ErrorHandler::logCustomError('[PayPal] Unknown event type ' . Output::getClean($response->event_type));
 				break;
 		}
-
-
-
 	} catch(\PayPal\Exception\PayPalInvalidCredentialException $e){
 		// Error verifying webhook
 		ErrorHandler::logCustomError('[PayPal] ' . $e->errorMessage());

--- a/upload/modules/Resources/pages/resources/listener.php
+++ b/upload/modules/Resources/pages/resources/listener.php
@@ -30,7 +30,17 @@ if(isset($_GET['key']) && $_GET['key'] == $data){
 
 	$bodyReceived = file_get_contents('php://input');
 
-	$headers = getallheaders();
+	if (!function_exists('getallheaders')) {
+		function getallheaders() {
+			$headers = [];
+			foreach ($_SERVER as $name => $value) {
+				if (substr($name, 0, 5) == 'HTTP_') {
+					$headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+				}
+			}
+			return $headers;
+		}
+	}
 	$headers = array_change_key_case($headers, CASE_UPPER);
 
 	$signatureVerification = new \PayPal\Api\VerifyWebhookSignature();

--- a/upload/modules/Resources/pages/resources/listener.php
+++ b/upload/modules/Resources/pages/resources/listener.php
@@ -40,6 +40,8 @@ if(isset($_GET['key']) && $_GET['key'] == $data){
 			}
 			return $headers;
 		}
+	} else {
+		$headers = getallheaders();
 	}
 	$headers = array_change_key_case($headers, CASE_UPPER);
 


### PR DESCRIPTION
This PR is two-part. First is the solution to the current problem mentioned in #43:

```
[2021-07-01, 09:11:23] /home/user/public_html/site/modules/Resources/pages/resources/listener.php(33): Call to undefined function getallheaders()
```

According to this [SO](
https://stackoverflow.com/questions/41427359/phpunit-getallheaders-not-work) post, the `getallheaders` method does not exist in all environments. I'm using Pebblehost (a NamelessMC [partner](https://pebblehost.com/partners)), so I hope you agree this solution is desirable. However, it's still not enough to get PayPal integration working.

It turns out that the PayPal headers are also invalid. For example, instead of expected `PAYPAL-CERT-URL` the webhook returns `HTTP_PAYPAL_CERT_URL` instead. I suspect this is because PayPal thinks we're using the Python SDK, but I couldn't find a way to specify otherwise (and besides v1 is deprecated). I hope you'll find the solution in my final commit acceptable. 