### PR TITLE
Remove non-existing argument

### DIFF
--- a/upload/modules/Resources/pages/user/resources.php
+++ b/upload/modules/Resources/pages/user/resources.php
@@ -80,7 +80,7 @@ if(count($purchased_resources)){
             'name' => Output::getClean($resource->name),
             'author_username' => $author->getDisplayname(true),
             'author_nickname' => $author->getDisplayname(),
-            'author_avatar' => $author->getAvatar('', 256),
+            'author_avatar' => $author->getAvatar(256),
             'author_style' => $author->getGroupStyle(),
             'author_link' => $author->getProfileURL(),
             'latest_version' => Output::getClean($resource->version),


### PR DESCRIPTION
The getAvatar function was called with a non-existing argument and threw errors.