### PR TITLE
Add discount field to paid resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The Nameless-Resources module allows users to share zip files, GitHub projects and external links to your website, either freely or requiring a PayPal purchase.
 
 ## Requirements
-- NamelessMC version 2 pre-release 13
+- NamelessMC version 2 pre-release 13+
 
 ## Installation
 - Upload the contents of the **upload** directory straight into your NamelessMC installation's directory

--- a/upload/custom/templates/DefaultRevamp/resources/author.tpl
+++ b/upload/custom/templates/DefaultRevamp/resources/author.tpl
@@ -42,11 +42,11 @@
                                                     <a>{$resource.name}</a> <span
                                                         class="version"><small>{$resource.version}</small></span>
                                                     {if isset($resource.price)}
+                                                        <span class="res right floated ui mini label">{$resource.price} {$CURRENCY}</span>
                                                         {if isset($resource.discount)}
-                                                            <span class="res green right floated ui mini label">{$resource.discount}% off</span>
+                                                            <span class="res green right floated ui mini label" style="margin-left:5px;">
+                                                                {$resource.discount}% off</span>
                                                         {/if}
-                                                        <span class="res right floated ui mini label"
-                                                            style="margin-left:5px;">{$resource.price} {$CURRENCY}</span>
                                                     {/if}
                                                     <br />
                                                 </div>

--- a/upload/custom/templates/DefaultRevamp/resources/author.tpl
+++ b/upload/custom/templates/DefaultRevamp/resources/author.tpl
@@ -42,6 +42,9 @@
                                                     <a>{$resource.name}</a> <span
                                                         class="version"><small>{$resource.version}</small></span>
                                                     {if isset($resource.price)}
+                                                        {if isset($resource.discount)}
+                                                            <span class="res green right floated ui mini label">{$resource.discount}% off</span>
+                                                        {/if}
                                                         <span class="res right floated ui mini label"
                                                             style="margin-left:5px;">{$resource.price} {$CURRENCY}</span>
                                                     {/if}

--- a/upload/custom/templates/DefaultRevamp/resources/category.tpl
+++ b/upload/custom/templates/DefaultRevamp/resources/category.tpl
@@ -48,9 +48,15 @@
                                                 <img src="{$resource.icon}" class="ui medium rounded image">
                                                 <div class="content">
                                                     <a>{$resource.name}</a>
-                                                    <small>{$resource.version}</small> {if isset($resource.price)}<span
-                                                            class="res right floated ui mini label">{$resource.price}
-                                                        {$CURRENCY}</span>{/if}<br />
+                                                    <small>{$resource.version}</small>
+                                                    {if isset($resource.price)}
+                                                        {if isset($resource.discount)}
+                                                            <span class="res green right floated ui mini label">
+                                                                {$resource.discount}% off</span>
+                                                        {/if}
+                                                        <span class="res right floated ui mini label">{$resource.price}
+                                                            {$CURRENCY}</span>
+                                                    {/if}<br />
                                                     <div class="sub header">
                                                         {if $resource.short_description}
                                                             {$resource.short_description}

--- a/upload/custom/templates/DefaultRevamp/resources/category.tpl
+++ b/upload/custom/templates/DefaultRevamp/resources/category.tpl
@@ -6,7 +6,7 @@
         <div class="ui stackable grid">
             <div class="ui row">
                 <div class="twelve wide column">
-                    <h1 style="display:inline" class="white">{$CATEGORY_NAME}</h1>
+                    <h2 style="display:inline" class="white">{$CATEGORY_NAME}</h1>
 
                     <span class="res right floated">
                         <a href="{$BACK_LINK}" class="ui button">{$BACK}</a>
@@ -26,10 +26,11 @@
                     <div class="ui divider"></div>
 
                     {if $LATEST_RESOURCES}
-                        <table class="ui fixed single line selectable unstackable small padded res table">
+
+                        <table class="ui fixed single line selectable unstackable small padded res table" id="sticky-threads">
                             <thead>
                                 <tr>
-                                    <th class="eight wide">
+                                    <th class="nine wide">
                                         <h4>{$RESOURCE}</h4>
                                     </th>
                                     <th class="three wide">
@@ -44,26 +45,28 @@
                                 {foreach from=$LATEST_RESOURCES item=resource}
                                     <tr onclick="window.location.href='{$resource.link}'">
                                         <td>
-                                            <h5 class="ui image header" style="margin: 0;">
-                                                <img src="{$resource.icon}" class="ui medium rounded image">
-                                                <div class="content">
-                                                    <a>{$resource.name}</a>
-                                                    <small>{$resource.version}</small>
-                                                    {if isset($resource.price)}
-                                                        {if isset($resource.discount)}
-                                                            <span class="res green right floated ui mini label">
-                                                                {$resource.discount}% off</span>
+                                            <h5 class="ui image header" style="margin: 0; width: 100%;">
+                                            <div class="title" style="width: 100%;">
+                                                <img src="{$resource.icon}" class="floated ui mini rounded image">
+                                                    <div class="content">
+                                                        <a>{$resource.name}</a> <span
+                                                            class="version"><small>{$resource.version}</small></span>
+                                                        {if isset($resource.price)}
+                                                            <span class="res right floated ui mini label">{$resource.price} {$CURRENCY}</span>
+                                                            {if isset($resource.discount)}
+                                                                <span class="res green right floated ui mini label" style="margin-left:5px;">
+                                                                    {$resource.discount}% off</span>
+                                                            {/if}
                                                         {/if}
-                                                        <span class="res right floated ui mini label">{$resource.price}
-                                                            {$CURRENCY}</span>
-                                                    {/if}<br />
-                                                    <div class="sub header">
-                                                        {if $resource.short_description}
-                                                            {$resource.short_description}
-                                                        {else}
-                                                            {$resource.description}
-                                                        {/if}
-                                                        <br />{$resource.category}
+                                                        <br />
+                                                        <div class="sub header">
+                                                            {if $resource.short_description}
+                                                                {$resource.short_description}
+                                                            {else}
+                                                                {$resource.description}
+                                                            {/if}
+                                                            <br />{$resource.category}
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </h5>

--- a/upload/custom/templates/DefaultRevamp/resources/edit_resource.tpl
+++ b/upload/custom/templates/DefaultRevamp/resources/edit_resource.tpl
@@ -46,6 +46,15 @@
                         </div>
                     </div>
                 </div>
+                <div class="field" id="discountFormGroup">
+                    <label for="inputDiscount">{$DISCOUNT}</label>
+                    <div class="ui right labeled input">
+                        <input type="number" min="0" id="inputDiscount" name="discount" value="{$RESOURCE_DISCOUNT}">
+                        <div class="ui basic label">
+                            %
+                        </div>
+                    </div>
+                </div>
             {/if}
 
             <input type="hidden" name="token" value="{$TOKEN}">

--- a/upload/custom/templates/DefaultRevamp/resources/index.tpl
+++ b/upload/custom/templates/DefaultRevamp/resources/index.tpl
@@ -49,12 +49,11 @@
                                                     <a>{$resource.name}</a> <span
                                                         class="version"><small>{$resource.version}</small></span>
                                                     {if isset($resource.price)}
+                                                        <span class="res right floated ui mini label">{$resource.price} {$CURRENCY}</span>
                                                         {if isset($resource.discount)}
-                                                            <span class="res green right floated ui mini label">
+                                                            <span class="res green right floated ui mini label" style="margin-left:5px;">
                                                                 {$resource.discount}% off</span>
                                                         {/if}
-                                                        <span class="res right floated ui mini label"
-                                                            style="margin-left:5px;">{$resource.price} {$CURRENCY}</span>
                                                     {/if}
                                                     <br />
                                                 </div>

--- a/upload/custom/templates/DefaultRevamp/resources/index.tpl
+++ b/upload/custom/templates/DefaultRevamp/resources/index.tpl
@@ -49,6 +49,10 @@
                                                     <a>{$resource.name}</a> <span
                                                         class="version"><small>{$resource.version}</small></span>
                                                     {if isset($resource.price)}
+                                                        {if isset($resource.discount)}
+                                                            <span class="res green right floated ui mini label">
+                                                                {$resource.discount}% off</span>
+                                                        {/if}
                                                         <span class="res right floated ui mini label"
                                                             style="margin-left:5px;">{$resource.price} {$CURRENCY}</span>
                                                     {/if}

--- a/upload/custom/templates/DefaultRevamp/resources/resource.tpl
+++ b/upload/custom/templates/DefaultRevamp/resources/resource.tpl
@@ -52,11 +52,13 @@
                     <a href="{$DOWNLOAD_URL}" class="ui blue button" target="_blank">{$DOWNLOAD}</a>
                 {elseif isset($PURCHASE_FOR_PRICE)}
                     <a {if isset($PURCHASE_LINK)}href="{$PURCHASE_LINK}" 
-                    {else}disabled
-                            {/if}class="ui blue{if !isset($PURCHASE_LINK)} disabled{/if} button">{$PURCHASE_FOR_PRICE}</a>
-                    {elseif isset($PAYMENT_PENDING)}
-                        <button type="button" disabled class="ui blue button">{$PAYMENT_PENDING}</button>
-                    {/if}
+                        {else}disabled
+                        {/if}class="ui blue{if !isset($PURCHASE_LINK)} disabled{/if} button">
+                        <i class="cart icon"></i>{$PURCHASE_FOR_PRICE}
+                    </a>
+                {elseif isset($PAYMENT_PENDING)}
+                    <button type="button" disabled class="ui blue button">{$PAYMENT_PENDING}</button>
+                {/if}
 
                     <span class="pull-right">
                         {if isset($CAN_EDIT)}

--- a/upload/modules/Resources/classes/Resources.php
+++ b/upload/modules/Resources/classes/Resources.php
@@ -221,4 +221,14 @@ class Resources {
         }
         return 'unknown';
     }
+    
+    public static function getPricePercent($price, $percent) {
+        if ($percent > 0 and $percent < 100) {
+            $price = $price - ($price * ($percent / 100));
+            $round = round($price, 2);
+            return number_format($round, 2, '.', '');
+        } else {
+            return $price;
+        }
+    }
 }

--- a/upload/modules/Resources/language/en_UK.json
+++ b/upload/modules/Resources/language/en_UK.json
@@ -40,6 +40,7 @@
     "resources/delete_resource": "Delete resource",
     "resources/delete_resources": "Delete resources",
     "resources/delete_review": "Delete Review",
+    "resources/discount": "Discount",
     "resources/download": "Download",
     "resources/downloads": "Downloads",
     "resources/editing_category": "Editing Category",

--- a/upload/modules/Resources/module.php
+++ b/upload/modules/Resources/module.php
@@ -65,7 +65,7 @@ class Resources_Module extends Module {
         $queries = new Queries();
         try {
             $data = $queries->createTable("resources_categories", " `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(32) NOT NULL, `description` text, `display_order` int(11) NOT NULL DEFAULT '0', PRIMARY KEY (`id`)", "ENGINE=$engine DEFAULT CHARSET=$charset");
-            $data = $queries->createTable("resources", " `id` int(11) NOT NULL AUTO_INCREMENT, `category_id` int(11) NOT NULL, `creator_id` int(11) NOT NULL, `name` varchar(64) NOT NULL, `short_description` varchar(64) NULL DEFAULT NULL, `has_icon` tinyint(1) NOT NULL DEFAULT '0', `icon` varchar(512) NULL DEFAULT NULL, `icon_updated` int(11) NOT NULL DEFAULT '0', `description` mediumtext NOT NULL, `contributors` text, `views` int(11) NOT NULL DEFAULT '0', `downloads` int(11) NOT NULL DEFAULT '0', `created` int(11) NOT NULL, `updated` int(11) NOT NULL, `github_url` varchar(128) DEFAULT NULL, `github_username` varchar(64) DEFAULT NULL, `github_repo_name` varchar(64) DEFAULT NULL, `rating` int(11) NOT NULL DEFAULT '0', `latest_version` varchar(32) DEFAULT NULL, `type` tinyint(1) NOT NULL DEFAULT '0', `price` varchar(16) DEFAULT NULL, `payment_email` varchar(256) DEFAULT NULL, PRIMARY KEY (`id`)", "ENGINE=$engine DEFAULT CHARSET=$charset");
+            $data = $queries->createTable("resources", " `id` int(11) NOT NULL AUTO_INCREMENT, `category_id` int(11) NOT NULL, `creator_id` int(11) NOT NULL, `name` varchar(64) NOT NULL, `short_description` varchar(64) NULL DEFAULT NULL, `has_icon` tinyint(1) NOT NULL DEFAULT '0', `icon` varchar(512) NULL DEFAULT NULL, `icon_updated` int(11) NOT NULL DEFAULT '0', `description` mediumtext NOT NULL, `contributors` text, `views` int(11) NOT NULL DEFAULT '0', `downloads` int(11) NOT NULL DEFAULT '0', `created` int(11) NOT NULL, `updated` int(11) NOT NULL, `github_url` varchar(128) DEFAULT NULL, `github_username` varchar(64) DEFAULT NULL, `github_repo_name` varchar(64) DEFAULT NULL, `rating` int(11) NOT NULL DEFAULT '0', `latest_version` varchar(32) DEFAULT NULL, `type` tinyint(1) NOT NULL DEFAULT '0', `price` varchar(16) DEFAULT NULL, `payment_email` varchar(256) DEFAULT NULL, `discount` int(11) DEFAULT NULL, PRIMARY KEY (`id`)", "ENGINE=$engine DEFAULT CHARSET=$charset");
             $data = $queries->createTable("resources_releases", " `id` int(11) NOT NULL AUTO_INCREMENT, `resource_id` int(11) NOT NULL, `category_id` int(11) NOT NULL, `release_title` varchar(128) NOT NULL, `release_description` mediumtext NOT NULL, `release_tag` varchar(16) NOT NULL, `created` int(11) NOT NULL, `downloads` int(11) NOT NULL DEFAULT '0', `rating` int(11) NOT NULL DEFAULT '0', `download_link` varchar(255) DEFAULT NULL, PRIMARY KEY (`id`)", "ENGINE=$engine DEFAULT CHARSET=$charset");
             $data = $queries->createTable("resources_comments", " `id` int(11) NOT NULL AUTO_INCREMENT, `resource_id` int(11) NOT NULL, `author_id` int(11) NOT NULL, `content` mediumtext NOT NULL, `release_tag` varchar(16) NOT NULL, `created` int(11) NOT NULL, `reply_id` int(11) DEFAULT NULL, `rating` int(11) NOT NULL DEFAULT '0', `hidden` tinyint(1) NOT NULL DEFAULT '0', PRIMARY KEY (`id`)", "ENGINE=$engine DEFAULT CHARSET=$charset");
             $data = $queries->createTable("resources_categories_permissions", " `id` int(11) NOT NULL AUTO_INCREMENT, `category_id` int(11) NOT NULL, `group_id` int(11) NOT NULL, `view` tinyint(1) NOT NULL DEFAULT '1', `post` tinyint(1) NOT NULL DEFAULT '1', `move_resource` tinyint(1) NOT NULL DEFAULT '1', `edit_resource` tinyint(1) NOT NULL DEFAULT '1', `delete_resource` tinyint(1) NOT NULL DEFAULT '1', `edit_review` tinyint(1) NOT NULL DEFAULT '1', `delete_review` tinyint(1) NOT NULL DEFAULT '1', `download` tinyint(1) NOT NULL DEFAULT '0', `premium` tinyint(1) NOT NULL DEFAULT '0', PRIMARY KEY (`id`)", "ENGINE=$engine DEFAULT CHARSET=$charset");
@@ -90,7 +90,11 @@ class Resources_Module extends Module {
     }
 
     public function onEnable(){
-
+        try{
+           DB::getInstance()->addColumn('resources', 'discount', "int(11) DEFAULT NULL");
+        } catch(Exception $e){
+           // Already exists
+        }
     }
 
     public function onDisable(){

--- a/upload/modules/Resources/pages/resources/author.php
+++ b/upload/modules/Resources/pages/resources/author.php
@@ -133,6 +133,12 @@ if (count($latest_releases)) {
                 $releases_array[$results->data[$n]->id]['price'] = Output::getClean($results->data[$n]->price);
             }
         
+            if ($resource->type == 1) {
+                if ($resource->discount > 0 and $resource->discount < 100) {
+                    $releases_array[$resource->id]['discount'] = Output::getClean($resource->discount);
+                }
+                $releases_array[$resource->id]['price'] = Output::getClean(Resources::getPricePercent($resource->price, $resource->discount));
+            }
             // Check if resource icon uploaded
             if($results->data[$n]->has_icon == 1 ) {
                 $releases_array[$results->data[$n]->id]['icon'] = $results->data[$n]->icon;

--- a/upload/modules/Resources/pages/resources/category.php
+++ b/upload/modules/Resources/pages/resources/category.php
@@ -150,7 +150,10 @@ if(count($latest_releases)){
             ];
 
             if ($resource->type == 1) {
-                $releases_array[$resource->id]['price'] = Output::getClean($resource->price);
+                if ($resource->discount > 0 and $resource->discount < 100) {
+                    $releases_array[$resource->id]['discount'] = Output::getClean($resource->discount);
+                }
+                $releases_array[$resource->id]['price'] = Output::getClean(Resources::getPricePercent($resource->price, $resource->discount));
             }
 
             // Check if resource icon uploaded

--- a/upload/modules/Resources/pages/resources/index.php
+++ b/upload/modules/Resources/pages/resources/index.php
@@ -126,9 +126,12 @@ if(count($latest_releases)){
             ];
 
             if ($resource->type == 1) {
-                $releases_array[$resource->id]['price'] = Output::getClean($resource->price);
+                if ($resource->discount > 0 and $resource->discount < 100) {
+                    $releases_array[$resource->id]['discount'] = Output::getClean($resource->discount);
+                }
+                $releases_array[$resource->id]['price'] = Output::getClean(Resources::getPricePercent($resource->price, $resource->discount));
             }
-              // Check if resource icon uploaded
+            // Check if resource icon uploaded
             if ($resource->has_icon == 1) {
                 $releases_array[$resource->id]['icon'] = $resource->icon;
             } else {

--- a/upload/modules/Resources/pages/resources/purchase.php
+++ b/upload/modules/Resources/pages/resources/purchase.php
@@ -159,7 +159,7 @@ if(isset($_GET['do'])){
                         $payee->setEmail($author_paypal);
 
                         $amount = new \PayPal\Api\Amount();
-                        $amount->setTotal($resource->price);
+                        $amount->setTotal($resource->price, $resource->discount);
                         $amount->setCurrency($currency);
 
                         $transaction = new \PayPal\Api\Transaction();

--- a/upload/modules/Resources/pages/resources/resource.php
+++ b/upload/modules/Resources/pages/resources/resource.php
@@ -308,6 +308,12 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
     // Get Reviews Count
     $reviews = DB::getInstance()->query('SELECT COUNT(*) AS c FROM nl2_resources_comments WHERE resource_id = ? AND hidden = 0', [$resource->id])->first()->c;
 
+    if ($resource->discount >= 0 and $resource->discount < 100) {
+        $smarty->assign(array(
+            'RESOURCE_DISCOUNT' => $resource->discount
+        ));
+    }
+
     // Assign Smarty variables
     $smarty->assign([
         'VIEWING_RESOURCE' => $resource_language->get('resources', 'viewing_resource_x', ['resource' => Output::getClean($resource->name)]),
@@ -442,7 +448,8 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                         } else if($paid->status == 2 || $paid->status == 3){
                             // Cancelled
                             $smarty->assign([
-                                'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . Output::getClean($currency)]),
+                                'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' =>  ($resource->discount > 0
+                                    ? '<small><s>' . $resource->price . '</s></small> ' . Output::getClean(Resources::getPricePercent($resource->price, $resource->discount)) : $resource->price) . ' ' . Output::getClean($currency)]),
                                 'PURCHASE_LINK' => URL::build('/resources/purchase/' . Output::getClean($resource->id) . '-' . Output::getClean(Util::stringToURL($resource->name)))
                             ]);
 
@@ -450,7 +457,8 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                     } else {
                         // Needs to purchase
                         $smarty->assign([
-                            'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . Output::getClean($currency)]),
+                            'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' =>  ($resource->discount > 0
+                                ? '<small><s>' . $resource->price . '</s></small> ' . Output::getClean(Resources::getPricePercent($resource->price, $resource->discount)) : $resource->price) . ' ' . Output::getClean($currency)]),
                             'PURCHASE_LINK' => URL::build('/resources/purchase/' . Output::getClean($resource->id) . '-' . Output::getClean(Util::stringToURL($resource->name)))
                         ]);
                     }
@@ -459,7 +467,7 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
 
         } else {
             $smarty->assign([
-                'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . $currency])
+                'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean(Resources::getPricePercent($resource->price, $resource->discount)) . ' ' . $currency])
             ]);
         }
     }
@@ -710,7 +718,8 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                                 } else if($paid->status == 2){
                                     // Cancelled
                                     $smarty->assign([
-                                        'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . Output::getClean($currency)]),
+                                        'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' =>  ($resource->discount > 0
+                                            ? '<small><s>' . $resource->price . '</s></small> ' . Output::getClean(Resources::getPricePercent($resource->price, $resource->discount)) : $resource->price) . ' ' . Output::getClean($currency)]),
                                         'PURCHASE_LINK' => URL::build('/resources/purchase/' . Output::getClean($resource->id) . '-' . Output::getClean(Util::stringToURL($resource->name)))
                                     ]);
 
@@ -718,7 +727,8 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                             } else {
                                 // Needs to purchase
                                 $smarty->assign([
-                                    'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . Output::getClean($currency)]),
+                                    'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' =>  ($resource->discount > 0
+                                        ? '<small><s>' . $resource->price . '</s></small> ' . Output::getClean(Resources::getPricePercent($resource->price, $resource->discount)) : $resource->price) . ' ' . Output::getClean($currency)]),
                                     'PURCHASE_LINK' => URL::build('/resources/purchase/' . Output::getClean($resource->id) . '-' . Output::getClean(Util::stringToURL($resource->name)))
                                 ]);
                             }
@@ -903,7 +913,8 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                                 } else if($paid->status == 2){
                                     // Cancelled
                                     $smarty->assign([
-                                        'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . Output::getClean($currency)]),
+                                        'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' =>  ($resource->discount > 0
+                                            ? '<small><s>' . $resource->price . '</s></small> ' . Output::getClean(Resources::getPricePercent($resource->price, $resource->discount)) : $resource->price) . ' ' . Output::getClean($currency)]),
                                         'PURCHASE_LINK' => URL::build('/resources/purchase/' . Output::getClean($resource->id) . '-' . Output::getClean(Util::stringToURL($resource->name)))
                                     ]);
 
@@ -911,7 +922,8 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                             } else {
                                 // Needs to purchase
                                 $smarty->assign([
-                                    'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . Output::getClean($currency)]),
+                                    'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' =>  ($resource->discount > 0
+                                        ? '<small><s>' . $resource->price . '</s></small> ' . Output::getClean(Resources::getPricePercent($resource->price, $resource->discount)) : $resource->price) . ' ' . Output::getClean($currency)]),
                                     'PURCHASE_LINK' => URL::build('/resources/purchase/' . Output::getClean($resource->id) . '-' . Output::getClean(Util::stringToURL($resource->name)))
                                 ]);
                             }
@@ -1184,7 +1196,8 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                                 } else if($paid->status == 2 || $paid->status == 3){
                                     // Cancelled
                                     $smarty->assign([
-                                        'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . Output::getClean($currency)]),
+                                        'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' =>  ($resource->discount > 0
+                                            ? '<small><s>' . $resource->price . '</s></small> ' . Output::getClean(Resources::getPricePercent($resource->price, $resource->discount)) : $resource->price) . ' ' . Output::getClean($currency)]),
                                         'PURCHASE_LINK' => URL::build('/resources/purchase/' . Output::getClean($resource->id) . '-' . Output::getClean(Util::stringToURL($resource->name)))
                                     ]);
 
@@ -1192,7 +1205,8 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                             } else {
                                 // Needs to purchase
                                 $smarty->assign([
-                                    'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . Output::getClean($currency)]),
+                                    'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' =>  ($resource->discount > 0
+                                        ? '<small><s>' . $resource->price . '</s></small> ' . Output::getClean(Resources::getPricePercent($resource->price, $resource->discount)) : $resource->price) . ' ' . Output::getClean($currency)]),
                                     'PURCHASE_LINK' => URL::build('/resources/purchase/' . Output::getClean($resource->id) . '-' . Output::getClean(Util::stringToURL($resource->name)))
                                 ]);
                             }
@@ -1726,6 +1740,15 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                 // Can edit
                 $errors = [];
 
+                if ($resource->discount >= 0 and $resource->discount < 100) {
+                    $discount = $resource->discount;
+                    $smarty->assign(array(
+                        'RESOURCE_DISCOUNT' => $discount
+                    ));
+                } else {
+                    $discount = 0;
+                }
+                
                 if(Input::exists()){
                     if(Token::check(Input::get('token'))){
                         $validation = Validate::check($_POST, [
@@ -1773,6 +1796,11 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                                 $price = number_format($_POST['price'], 2, '.', '');
                             } else
                                 $price = $resource->price;
+                            
+                            if($resource->type == 1 && isset($_POST['discount']) && is_numeric($_POST['discount']) && $_POST['discount'] >= 0 && $_POST['discount'] < 100){
+                                $discount = $_POST['discount'];
+                            } else
+                                $discount = $resource->discount;
 
                             try {
                                 // TODO: hooks
@@ -1783,7 +1811,8 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                                     'short_description' => Output::getClean(Input::get('short_description')),
                                     'description' => $content,
                                     'contributors' => Output::getClean(Input::get('contributors')),
-                                    'price' => $price
+                                    'price' => $price,
+                                    'discount' => $discount
                                 ]);
 
                                 Redirect::to(URL::build('/resources/resource/' . $resource->id . '-' . Util::stringToURL(Input::get('title'))));
@@ -1851,7 +1880,9 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                 $smarty->assign([
                     'PRICE' => $resource_language->get('resources', 'price'),
                     'RESOURCE_PRICE' => Output::getClean($resource->price),
-                    'CURRENCY' => $currency
+                    'CURRENCY' => $currency,
+                    'DISCOUNT' => $resource_language->get('resources', 'discount'),
+                    'RESOURCE_DISCOUNT' => Output::getClean($resource->discount)
                 ]);
             }
 


### PR DESCRIPTION
You can view this PR live on our website at https://lectern.browsit.org/resources/

Adds the potential to include a discount for premium resources, namely:

- Discount field below price field during creation
- Green label indicating sale next to price on resource index
- Strikethrough price on purchase button with cart icon
- Discount will be included in total at checkout
- Update category view like #70

Code was [originally written by GIGABAIT](https://github.com/Boombastic20/Nameless-Resources/pull/1)/Mubeen at our request and has been notably updated over the past year in use. If you are not interested in these features, we can maintain a separate module, but we think a merge would benefit the community more.

Please note that while the modern PayPal REST API has methods for discounts which would allow them to appear as such on the order information, the PHP SDK currently in use does not have that capability outside of bulk invoices.