### PR TITLE
Disable button in Versions tab if not logged in

### DIFF
--- a/upload/custom/templates/DefaultRevamp/resources/resource_all_versions.tpl
+++ b/upload/custom/templates/DefaultRevamp/resources/resource_all_versions.tpl
@@ -76,8 +76,13 @@
                                         </td>
                                         <td>
                                             <span class="res right floated">
+                                                {if isset($LOG_IN_TO_DOWNLOAD)}
+                                                <a disabled class="ui blue disabled button mini"
+                                                    target="_blank">{$LOG_IN_TO_DOWNLOAD}</a>
+                                                {else}
                                                 <a href="{$release.download_url}" class="ui blue button mini"
                                                     target="_blank">{$DOWNLOAD}</a>
+                                                {/if}
                                             </span>
                                         </td>
                                     </tr>

--- a/upload/modules/Resources/pages/resources/resource.php
+++ b/upload/modules/Resources/pages/resources/resource.php
@@ -922,6 +922,7 @@ if(!isset($_GET['releases']) && !isset($_GET['do']) && !isset($_GET['versions'])
                     $smarty->assign([
                         'PURCHASE_FOR_PRICE' => $resource_language->get('resources', 'purchase_for_x', ['price' => Output::getClean($resource->price) . ' ' . $currency])
                     ]);
+                    $smarty->assign('LOG_IN_TO_DOWNLOAD', $resource_language->get('resources', 'log_in_to_download'));
                 }
             }
 


### PR DESCRIPTION
Under a premium resource's Versions tab, each version would show a blue "Download" button. When not logged in, the button would send the users back to the Overview page when clicked. This request changes it to a greyed-out "Log in to download" button which cannot be clicked. The button becomes functional again once user has logged in.